### PR TITLE
Change local frontend port to 3000

### DIFF
--- a/.env
+++ b/.env
@@ -6,7 +6,7 @@ DOMAIN=localhost
 # DOMAIN=localhost.tiangolo.com
 
 # Used by the backend to generate links in emails to the frontend
-FRONTEND_HOST=http://localhost:5173
+FRONTEND_HOST=http://localhost:3000
 # In staging and production, set this env var to the frontend host, e.g.
 # FRONTEND_HOST=https://dashboard.example.com
 
@@ -17,7 +17,7 @@ PROJECT_NAME="Full Stack FastAPI Project"
 STACK_NAME=full-stack-fastapi-project
 
 # Backend
-BACKEND_CORS_ORIGINS="http://localhost,http://localhost:5173,https://localhost,https://localhost:5173,http://localhost.tiangolo.com"
+BACKEND_CORS_ORIGINS="http://localhost,http://localhost:3000,https://localhost,https://localhost:3000,http://localhost.tiangolo.com"
 SECRET_KEY=changethis
 FIRST_SUPERUSER=admin@example.com
 FIRST_SUPERUSER_PASSWORD=changethis

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,8 +20,8 @@
         {
             "type": "chrome",
             "request": "launch",
-            "name": "Debug Frontend: Launch Chrome against http://localhost:5173",
-            "url": "http://localhost:5173",
+            "name": "Debug Frontend: Launch Chrome against http://localhost:3000",
+            "url": "http://localhost:3000",
             "webRoot": "${workspaceFolder}/frontend"
         },
     ]

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -35,7 +35,7 @@ class Settings(BaseSettings):
     SECRET_KEY: str = secrets.token_urlsafe(32)
     # 60 minutes * 24 hours * 8 days = 8 days
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 60 * 24 * 8
-    FRONTEND_HOST: str = "http://localhost:5173"
+    FRONTEND_HOST: str = "http://localhost:3000"
     ENVIRONMENT: Literal["local", "staging", "production"] = "local"
 
     BACKEND_CORS_ORIGINS: Annotated[

--- a/development.md
+++ b/development.md
@@ -10,7 +10,7 @@ docker compose watch
 
 * Now you can open your browser and interact with these URLs:
 
-Frontend, built with Docker, with routes handled based on the path: http://localhost:5173
+Frontend, built with Docker, with routes handled based on the path: http://localhost:3000
 
 Backend, JSON based web API based on OpenAPI: http://localhost:8000
 
@@ -38,7 +38,7 @@ docker compose logs backend
 
 The Docker Compose files are configured so that each of the services is available in a different port in `localhost`.
 
-For the backend and frontend, they use the same port that would be used by their local development server, so, the backend is at `http://localhost:8000` and the frontend at `http://localhost:5173`.
+For the backend and frontend, they use the same port that would be used by their local development server, so, the backend is at `http://localhost:8000` and the frontend at `http://localhost:3000`.
 
 This way, you could turn off a Docker Compose service and start its local development service, and everything would keep working, because it all uses the same ports.
 
@@ -174,7 +174,7 @@ The production or staging URLs would use these same paths, but with your own dom
 
 Development URLs, for local development.
 
-Frontend: http://localhost:5173
+Frontend: http://localhost:3000
 
 Backend: http://localhost:8000
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -45,7 +45,7 @@ npm install
 npm run dev
 ```
 
-* Then open your browser at http://localhost:5173/.
+* Then open your browser at http://localhost:3000/.
 
 Notice that this live server is not running inside Docker, it's for local development, and that is the recommended workflow. Once you are happy with your frontend, you can build the frontend Docker image and start it, to test it in a production-like environment. But building the image at every change will not be as productive as running the local development server with live reload.
 


### PR DESCRIPTION
## Summary
- use `http://localhost:3000` as the default `FRONTEND_HOST`
- adjust CORS origins
- update docs and launch configuration to mention the new port

## Testing
- `pre-commit run --files .env .vscode/launch.json backend/app/core/config.py development.md frontend/README.md`

------
https://chatgpt.com/codex/tasks/task_b_6859a8dc97fc83278dbfd447636e8deb