### PR TITLE
Switch to NEXT_PUBLIC_API_BASE_URL variable

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -99,7 +99,7 @@ services:
     build:
       context: ./frontend
       args:
-        - VITE_API_URL=http://localhost:8000
+        - NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
         - NODE_ENV=development
 
   playwright:
@@ -107,7 +107,7 @@ services:
       context: ./frontend
       dockerfile: Dockerfile.playwright
       args:
-        - VITE_API_URL=http://backend:8000
+        - NEXT_PUBLIC_API_BASE_URL=http://backend:8000
         - NODE_ENV=production
     ipc: host
     depends_on:
@@ -116,7 +116,7 @@ services:
     env_file:
       - .env
     environment:
-      - VITE_API_URL=http://backend:8000
+      - NEXT_PUBLIC_API_BASE_URL=http://backend:8000
       - MAILCATCHER_HOST=http://mailcatcher:1080
       # For the reports when run locally
       - PLAYWRIGHT_HTML_HOST=0.0.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,7 +143,7 @@ services:
     build:
       context: ./frontend
       args:
-        - VITE_API_URL=https://api.${DOMAIN?Variable not set}
+        - NEXT_PUBLIC_API_BASE_URL=https://api.${DOMAIN?Variable not set}
         - NODE_ENV=production
     labels:
       - traefik.enable=true

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,2 +1,2 @@
-VITE_API_URL=http://localhost:8000
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
 MAILCATCHER_HOST=http://localhost:1080

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,7 +9,7 @@ RUN npm install
 
 COPY ./ /app/
 
-ARG VITE_API_URL=${VITE_API_URL}
+ARG NEXT_PUBLIC_API_BASE_URL=${NEXT_PUBLIC_API_BASE_URL}
 
 RUN npm run build
 

--- a/frontend/Dockerfile.playwright
+++ b/frontend/Dockerfile.playwright
@@ -10,4 +10,4 @@ RUN npx -y playwright install --with-deps
 
 COPY ./ /app/
 
-ARG VITE_API_URL=${VITE_API_URL}
+ARG NEXT_PUBLIC_API_BASE_URL=${NEXT_PUBLIC_API_BASE_URL}

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -103,10 +103,10 @@ Notice that everytime the backend changes (changing the OpenAPI schema), you sho
 
 ## Using a Remote API
 
-If you want to use a remote API, you can set the environment variable `VITE_API_URL` to the URL of the remote API. For example, you can set it in the `frontend/.env` file:
+If you want to use a remote API, you can set the environment variable `NEXT_PUBLIC_API_BASE_URL` to the URL of the remote API. For example, you can set it in the `frontend/.env` file:
 
 ```env
-VITE_API_URL=https://api.my-domain.example.com
+NEXT_PUBLIC_API_BASE_URL=https://api.my-domain.example.com
 ```
 
 Then, when you run the frontend, it will use that URL as the base URL for the API.

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -12,7 +12,7 @@ import { routeTree } from "./routeTree.gen"
 import { ApiError, OpenAPI } from "./client"
 import { CustomProvider } from "./components/ui/provider"
 
-OpenAPI.BASE = import.meta.env.VITE_API_URL
+OpenAPI.BASE = process.env.NEXT_PUBLIC_API_BASE_URL || ""
 OpenAPI.TOKEN = async () => {
   return localStorage.getItem("access_token") || ""
 }

--- a/frontend/tests/utils/privateApi.ts
+++ b/frontend/tests/utils/privateApi.ts
@@ -2,7 +2,7 @@
 // for local environments
 import { OpenAPI, PrivateService } from "../../src/client"
 
-OpenAPI.BASE = `${process.env.VITE_API_URL}`
+OpenAPI.BASE = `${process.env.NEXT_PUBLIC_API_BASE_URL}`
 
 export const createUser = async ({
   email,


### PR DESCRIPTION
## Summary
- use `NEXT_PUBLIC_API_BASE_URL` environment variable
- update docker-compose files
- update Playwright helpers
- update frontend startup to read `process.env.NEXT_PUBLIC_API_BASE_URL`
- update docs for the new variable

## Testing
- `pre-commit run --files docker-compose.override.yml docker-compose.yml frontend/.env frontend/Dockerfile frontend/Dockerfile.playwright frontend/README.md frontend/src/main.tsx frontend/tests/utils/privateApi.ts`

------
https://chatgpt.com/codex/tasks/task_b_6859ae96acb48327b467823942aaf498