### PR TITLE
Update frontend Docker setup

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -95,11 +95,11 @@ services:
   frontend:
     restart: "no"
     ports:
-      - "5173:80"
+      - "3000:3000"
     build:
       context: ./frontend
       args:
-        - VITE_API_URL=http://localhost:8000
+        - NEXT_PUBLIC_API_URL=http://localhost:8000
         - NODE_ENV=development
 
   playwright:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,14 +143,14 @@ services:
     build:
       context: ./frontend
       args:
-        - VITE_API_URL=https://api.${DOMAIN?Variable not set}
+        - NEXT_PUBLIC_API_URL=https://api.${DOMAIN?Variable not set}
         - NODE_ENV=production
     labels:
       - traefik.enable=true
       - traefik.docker.network=traefik-public
       - traefik.constraint-label=traefik-public
 
-      - traefik.http.services.${STACK_NAME?Variable not set}-frontend.loadbalancer.server.port=80
+      - traefik.http.services.${STACK_NAME?Variable not set}-frontend.loadbalancer.server.port=3000
 
       - traefik.http.routers.${STACK_NAME?Variable not set}-frontend-http.rule=Host(`dashboard.${DOMAIN?Variable not set}`)
       - traefik.http.routers.${STACK_NAME?Variable not set}-frontend-http.entrypoints=http

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,23 +1,24 @@
-# Stage 0, "build-stage", based on Node.js, to build and compile the frontend
-FROM node:20 AS build-stage
-
+# Stage 0: install dependencies
+FROM node:20 AS deps
 WORKDIR /app
-
-COPY package*.json /app/
-
+COPY package*.json ./
 RUN npm install
 
-COPY ./ /app/
-
-ARG VITE_API_URL=${VITE_API_URL}
-
+# Stage 1: build the Next.js app
+FROM node:20 AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+ARG NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
 RUN npm run build
 
-
-# Stage 1, based on Nginx, to have only the compiled app, ready for production with Nginx
-FROM nginx:1
-
-COPY --from=build-stage /app/dist/ /usr/share/nginx/html
-
-COPY ./nginx.conf /etc/nginx/conf.d/default.conf
-COPY ./nginx-backend-not-found.conf /etc/nginx/extra-conf.d/backend-not-found.conf
+# Stage 2: run the production server
+FROM node:20 AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=builder /app/package*.json ./
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/public ./public
+EXPOSE 3000
+CMD ["npm", "start"]


### PR DESCRIPTION
## Summary
- switch frontend Dockerfile to Node build and runtime
- expose port 3000 for the Next app in dev and production
- pass NEXT_PUBLIC_API_URL build arg instead of VITE_API_URL

## Testing
- `pre-commit run --files frontend/Dockerfile docker-compose.override.yml docker-compose.yml`

------
https://chatgpt.com/codex/tasks/task_b_6859aec055808327afd134db88381eb8